### PR TITLE
fix: LoadModuleConfig uses ConfigurationBuilder.BindConfiguration, fi…

### DIFF
--- a/Modules/Shop_Bhop/Shop_Bhop.cs
+++ b/Modules/Shop_Bhop/Shop_Bhop.cs
@@ -59,7 +59,7 @@ public class Shop_Bhop : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -71,10 +71,7 @@ public class Shop_Bhop : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)

--- a/Modules/Shop_DecoyTeleport/Shop_DecoyTeleport.cs
+++ b/Modules/Shop_DecoyTeleport/Shop_DecoyTeleport.cs
@@ -81,10 +81,7 @@ public class Shop_DecoyTeleport : BasePlugin
             return;
         }
 
-        if (handlersRegistered)
-        {
-            return;
-        }
+        UnregisterHandlers();
 
         Config = shopApi.LoadModuleConfig<DecoyModuleConfig>(
             ModulePluginId,
@@ -258,21 +255,28 @@ public class Shop_DecoyTeleport : BasePlugin
 
     public override void Unload()
     {
-        if (shopApi is not null)
-        {
-            shopApi.OnItemPurchased -= OnItemPurchased;
-            shopApi.OnBeforeItemPurchase -= OnBeforeItemPurchase;
-
-            if (!string.IsNullOrWhiteSpace(Config.Decoy.Id))
-            {
-                _ = shopApi.UnregisterItem(Config.Decoy.Id);
-            }
-        }
+        UnregisterHandlers();
 
         lock (stateSync)
         {
             armedPlayers.Clear();
             cooldownUntilUnixSeconds.Clear();
+        }
+    }
+
+    private void UnregisterHandlers()
+    {
+        if (!handlersRegistered || shopApi is null)
+        {
+            return;
+        }
+
+        shopApi.OnItemPurchased -= OnItemPurchased;
+        shopApi.OnBeforeItemPurchase -= OnBeforeItemPurchase;
+
+        if (!string.IsNullOrWhiteSpace(Config.Decoy.Id))
+        {
+            _ = shopApi.UnregisterItem(Config.Decoy.Id);
         }
 
         handlersRegistered = false;

--- a/Modules/Shop_Flags/Shop_Flags.cs
+++ b/Modules/Shop_Flags/Shop_Flags.cs
@@ -56,7 +56,7 @@ public class Shop_Flags : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -68,8 +68,7 @@ public class Shop_Flags : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-            RegisterItemsAndHandlers();
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)

--- a/Modules/Shop_HitSounds/Shop_HitSounds.cs
+++ b/Modules/Shop_HitSounds/Shop_HitSounds.cs
@@ -48,7 +48,7 @@ public class Shop_HitSounds : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -60,10 +60,7 @@ public class Shop_HitSounds : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)
@@ -246,34 +243,17 @@ public class Shop_HitSounds : BasePlugin
 
     private void OnItemSold(IPlayer player, ShopItemDefinition item, decimal creditedAmount)
     {
-        if (!registeredItemIds.Contains(item.Id) || shopApi == null)
+        if (!registeredItemIds.Contains(item.Id))
         {
             return;
-        }
-
-        // If sold while equipped, make sure any other enabled item becomes active source.
-        foreach (var otherItemId in registeredItemOrder)
-        {
-            if (shopApi.IsItemEnabled(player, otherItemId))
-            {
-                return;
-            }
         }
     }
 
     private void OnItemExpired(IPlayer player, ShopItemDefinition item)
     {
-        if (!registeredItemIds.Contains(item.Id) || shopApi == null)
+        if (!registeredItemIds.Contains(item.Id))
         {
             return;
-        }
-
-        foreach (var otherItemId in registeredItemOrder)
-        {
-            if (shopApi.IsItemEnabled(player, otherItemId))
-            {
-                return;
-            }
         }
     }
 

--- a/Modules/Shop_Killscreen/Shop_Killscreen.cs
+++ b/Modules/Shop_Killscreen/Shop_Killscreen.cs
@@ -12,7 +12,7 @@ namespace ShopCore;
 
 [PluginMetadata(
     Id = "Shop_Killscreen",
-    Name = "Shpo Killscreen",
+    Name = "Shop Killscreen",
     Author = "T3Marius",
     Version = "1.0.0",
     Description = "ShopCore module with killscreen items"
@@ -47,21 +47,18 @@ public class Shop_Killscreen : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
     public override void OnSharedInterfaceInjected(IInterfaceManager interfaceManager)
     {
         if (shopApi == null)
         {
-            Core.Logger.LogWarning("ShopCore API is not available. SmokeColor items will not be registered.");
+            Core.Logger.LogWarning("ShopCore API is not available. Killscreen items will not be registered.");
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
     public override void Load(bool hotReload)
     {
@@ -146,7 +143,7 @@ public class Shop_Killscreen : BasePlugin
 
             if (!shopApi.RegisterItem(definition))
             {
-                Core.Logger.LogWarning("Failed to register smokecolor item '{ItemId}'.", definition.Id);
+                Core.Logger.LogWarning("Failed to register killscreen item '{ItemId}'.", definition.Id);
                 continue;
             }
 
@@ -277,7 +274,7 @@ public class Shop_Killscreen : BasePlugin
         if (itemType == ShopItemType.Consumable)
         {
             Core.Logger.LogWarning(
-                "Skipping item '{ItemId}' because smoke color items cannot use Type '{Type}'.",
+                "Skipping item '{ItemId}' because killscreen items cannot use Type '{Type}'.",
                 itemId,
                 itemType
             );

--- a/Modules/Shop_Parachute/Shop_Parachute.cs
+++ b/Modules/Shop_Parachute/Shop_Parachute.cs
@@ -65,7 +65,7 @@ public class Shop_Parachute : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -77,10 +77,7 @@ public class Shop_Parachute : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)

--- a/Modules/Shop_PlayerColor/Shop_PlayerColor.cs
+++ b/Modules/Shop_PlayerColor/Shop_PlayerColor.cs
@@ -63,7 +63,7 @@ public class Shop_PlayerColor : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -75,10 +75,7 @@ public class Shop_PlayerColor : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)

--- a/Modules/Shop_PlayerModels/Shop_PlayerModels.cs
+++ b/Modules/Shop_PlayerModels/Shop_PlayerModels.cs
@@ -1,4 +1,7 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ShopCore.Contract;
 using SwiftlyS2.Shared;
 using SwiftlyS2.Shared.Events;
@@ -22,9 +25,8 @@ namespace ShopCore;
 public class Shop_PlayerModels : BasePlugin
 {
     private const string ShopCoreInterfaceKey = "ShopCore.API.v2";
-    private const string ModulePluginId = "Shop_PlayerModels";
-    private const string TemplateFileName = "playermodels_config.jsonc";
-    private const string TemplateSectionName = "Main";
+    private const string ConfigFileName = "config.jsonc";
+    private const string ConfigSectionName = "Main";
     private const string DefaultCategory = "Visuals/Player Models";
     private const float PreviewDurationSeconds = 8f;
     private const float PreviewDistance = 75f;
@@ -40,6 +42,8 @@ public class Shop_PlayerModels : BasePlugin
     private readonly Dictionary<int, PlayerModelPreviewState> previewStateByPlayerId = new();
     private long previewSessionCounter;
 
+    private PlayerModelsModuleConfig? moduleConfig;
+    private ServiceProvider? serviceProvider;
     private PlayerModelsModuleSettings runtimeSettings = new();
 
     public Shop_PlayerModels(ISwiftlyCore core) : base(core)
@@ -61,7 +65,7 @@ public class Shop_PlayerModels : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -73,14 +77,12 @@ public class Shop_PlayerModels : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)
     {
+        LoadModuleConfig();
         Core.Event.OnPrecacheResource += OnPrecacheResource;
 
         if (shopApi is not null && !handlersRegistered)
@@ -107,6 +109,9 @@ public class Shop_PlayerModels : BasePlugin
         }
 
         UnregisterItemsAndHandlers();
+        serviceProvider?.Dispose();
+        serviceProvider = null;
+        moduleConfig = null;
     }
 
     [GameEventHandler(HookMode.Post)]
@@ -163,12 +168,16 @@ public class Shop_PlayerModels : BasePlugin
 
         UnregisterItemsAndHandlers();
 
-        var moduleConfig = shopApi.LoadModuleConfig<PlayerModelsModuleConfig>(
-            ModulePluginId,
-            TemplateFileName,
-            TemplateSectionName
-        );
-        NormalizeConfig(moduleConfig);
+        if (moduleConfig == null)
+        {
+            LoadModuleConfig();
+        }
+
+        if (moduleConfig == null)
+        {
+            Core.Logger.LogWarning("PlayerModels config could not be loaded.");
+            return;
+        }
 
         runtimeSettings = moduleConfig.Settings;
 
@@ -181,14 +190,7 @@ public class Shop_PlayerModels : BasePlugin
             moduleConfig = CreateDefaultConfig();
             category = moduleConfig.Settings.Category;
             runtimeSettings = moduleConfig.Settings;
-
-            _ = shopApi.SaveModuleConfig(
-                ModulePluginId,
-                moduleConfig,
-                TemplateFileName,
-                TemplateSectionName,
-                overwrite: true
-            );
+            Core.Logger.LogWarning("PlayerModels config has no items. Using in-memory defaults.");
         }
 
         var registeredCount = 0;
@@ -222,6 +224,24 @@ public class Shop_PlayerModels : BasePlugin
             "Shop_PlayerModels initialized. RegisteredItems={RegisteredItems}",
             registeredCount
         );
+    }
+
+    private void LoadModuleConfig()
+    {
+        serviceProvider?.Dispose();
+        serviceProvider = null;
+
+        Core.Configuration.InitializeJsonWithModel<PlayerModelsModuleConfig>(ConfigFileName, ConfigSectionName)
+            .Configure(builder => builder.AddJsonFile(ConfigFileName, false, true));
+
+        ServiceCollection services = new();
+        services.AddSwiftly(Core)
+                .AddOptionsWithValidateOnStart<PlayerModelsModuleConfig>()
+                .BindConfiguration(ConfigSectionName);
+
+        serviceProvider = services.BuildServiceProvider();
+        moduleConfig = serviceProvider.GetRequiredService<IOptions<PlayerModelsModuleConfig>>().Value;
+        NormalizeConfig(moduleConfig);
     }
 
     private void UnregisterItemsAndHandlers()

--- a/Modules/Shop_Rewards/Shop_Rewards.cs
+++ b/Modules/Shop_Rewards/Shop_Rewards.cs
@@ -47,7 +47,7 @@ public class Shop_Rewards : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
 
         TryLoadConfig();
@@ -110,42 +110,27 @@ public class Shop_Rewards : BasePlugin
     [GameEventHandler(HookMode.Post)]
     public HookResult OnRoundStart(EventRoundStart e)
     {
-        List<IPlayer> onlinePlayers = Core.PlayerManager.GetAllValidPlayers().ToList();
+        if (shopApi == null)
+        {
+            return HookResult.Continue;
+        }
+
+        var onlinePlayers = Core.PlayerManager.GetAllValidPlayers().ToList();
 
         if (IsWarmupPeriod() && config.DisableInWarmup)
         {
             foreach (var player in onlinePlayers)
             {
-                var loc = Core.Translation.GetPlayerLocalizer(player);
-                var prefix = loc["shop.prefix"];
-                if (config.UseCorePrefix)
-                {
-                    var corePrefix = shopApi?.GetShopPrefix(player);
-                    if (!string.IsNullOrWhiteSpace(corePrefix))
-                    {
-                        prefix = corePrefix;
-                    }
-                }
-                player.SendChat($"{prefix} + {loc["module.disabled.warmup"]}");
+                NotifyPlayer(player, "module.disabled.warmup");
             }
             return HookResult.Continue;
         }
+
         if (onlinePlayers.Count < config.MinPlayers)
         {
             foreach (var player in onlinePlayers)
             {
-                var loc = Core.Translation.GetPlayerLocalizer(player);
-                var prefix = loc["shop.prefix"];
-                if (config.UseCorePrefix)
-                {
-                    var corePrefix = shopApi?.GetShopPrefix(player);
-                    if (!string.IsNullOrWhiteSpace(corePrefix))
-                    {
-                        prefix = corePrefix;
-                    }
-                }
-
-                player.SendChat($"{prefix} + {loc["module.disabled", config.MinPlayers]}");
+                NotifyPlayer(player, "module.disabled", config.MinPlayers);
             }
             return HookResult.Continue;
         }
@@ -306,20 +291,32 @@ public class Shop_Rewards : BasePlugin
         return true;
     }
 
-    private void SendRewardMessage(IPlayer player, string key, int rewardConfig)
+    private string GetPrefix(IPlayer player)
     {
         var loc = Core.Translation.GetPlayerLocalizer(player);
-        var prefix = loc["shop.prefix"];
         if (config.UseCorePrefix)
         {
             var corePrefix = shopApi?.GetShopPrefix(player);
             if (!string.IsNullOrWhiteSpace(corePrefix))
             {
-                prefix = corePrefix;
+                return corePrefix;
             }
         }
 
-        player.SendChat($"{prefix} {loc[key, rewardConfig]}");
+        return loc["shop.prefix"];
+    }
+
+    private void NotifyPlayer(IPlayer player, string key, params object[] args)
+    {
+        var loc = Core.Translation.GetPlayerLocalizer(player);
+        var msg = args.Length == 0 ? loc[key] : loc[key, args];
+        player.SendChat($"{GetPrefix(player)} {msg}");
+    }
+
+    private void SendRewardMessage(IPlayer player, string key, int rewardConfig)
+    {
+        var loc = Core.Translation.GetPlayerLocalizer(player);
+        player.SendChat($"{GetPrefix(player)} {loc[key, rewardConfig]}");
     }
     private bool IsWarmupPeriod()
     {

--- a/Modules/Shop_SmokeColor/Shop_SmokeColor.cs
+++ b/Modules/Shop_SmokeColor/Shop_SmokeColor.cs
@@ -50,7 +50,7 @@ public class Shop_SmokeColor : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -62,10 +62,7 @@ public class Shop_SmokeColor : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)

--- a/Modules/Shop_Tracers/Shop_Tracers.cs
+++ b/Modules/Shop_Tracers/Shop_Tracers.cs
@@ -61,7 +61,7 @@ public class Shop_Tracers : BasePlugin
         }
         catch (Exception ex)
         {
-            Core.Logger.LogInformation(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
+            Core.Logger.LogError(ex, "Failed to resolve shared interface '{InterfaceKey}'.", ShopCoreInterfaceKey);
         }
     }
 
@@ -73,10 +73,7 @@ public class Shop_Tracers : BasePlugin
             return;
         }
 
-        if (!handlersRegistered)
-        {
-            RegisterItemsAndHandlers();
-        }
+        RegisterItemsAndHandlers();
     }
 
     public override void Load(bool hotReload)

--- a/ShopCore/src/Api/Api.cs
+++ b/ShopCore/src/Api/Api.cs
@@ -1,8 +1,7 @@
 using System.Text.Json;
 using System.Reflection;
-using Cookies.Contract;
-using Economy.Contract;
 using FreeSql;
+using Microsoft.Extensions.Configuration;
 using ShopCore.Contract;
 using SwiftlyS2.Shared;
 using SwiftlyS2.Shared.Database;
@@ -289,23 +288,15 @@ internal sealed class ShopCoreApiV2 : IShopCoreApiV2
                 return new T();
             }
 
-            var rawText = File.ReadAllText(centralizedConfigPath);
-            using var document = JsonDocument.Parse(rawText, new JsonDocumentOptions
-            {
-                AllowTrailingCommas = true,
-                CommentHandling = JsonCommentHandling.Skip
-            });
+            var configRoot = new ConfigurationBuilder()
+                .AddJsonFile(centralizedConfigPath, optional: true, reloadOnChange: false)
+                .Build();
 
-            var payload = document.RootElement;
-            if (!string.IsNullOrWhiteSpace(sectionName) &&
-                payload.ValueKind == JsonValueKind.Object &&
-                payload.TryGetProperty(sectionName, out var sectionElement))
-            {
-                payload = sectionElement;
-            }
+            var result = string.IsNullOrWhiteSpace(sectionName)
+                ? configRoot.Get<T>()
+                : configRoot.GetSection(sectionName).Get<T>();
 
-            var config = JsonSerializer.Deserialize<T>(payload.GetRawText(), ConfigJsonOptions);
-            return config ?? new T();
+            return result ?? new T();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
…x module bugs and clean all modules

- Api.cs: Replace manual JsonDocument deserialization in LoadModuleConfig with ConfigurationBuilder + GetSection(sectionName).Get<T>() so config changes on disk are actually picked up (fixes hard-coded config issue)

- All modules: LogInformation → LogError in UseSharedInterface catch blocks

- All modules with handlersRegistered guard: Remove `if (!handlersRegistered)` in OnSharedInterfaceInjected so modules re-register correctly after ShopCore reloads (RegisterItemsAndHandlers is already idempotent via Unregister first)

- Shop_Killscreen: Fix typo \"Shpo Killscreen\" → \"Shop Killscreen\", fix copy-paste wrong log messages referencing smokecolor

- Shop_HitSounds: Remove dead loops in OnItemSold/OnItemExpired that iterated but never performed any action

- Shop_Rewards: Add missing shopApi == null guard in OnRoundStart, remove stray literal \" + \" in chat format strings, extract duplicate prefix resolution into GetPrefix() helper and add NotifyPlayer() helper

- Shop_DecoyTeleport: Extract UnregisterHandlers() and call it at start of InitializeModule() instead of early-returning when handlersRegistered=true, fixing re-init after ShopCore reload

- Shop_PlayerModels: Remove double blank line in RegisterItemsAndHandlers"